### PR TITLE
feat: central logging via rich + stdlib (TASK 030)

### DIFF
--- a/genevector/_logging.py
+++ b/genevector/_logging.py
@@ -1,0 +1,81 @@
+"""Central logging configuration for GeneVector.
+
+Exposes ``get_logger(name)`` for module-level loggers. Configures the
+``genevector`` parent logger lazily on first use with either RichHandler
+(TTY) or plain StreamHandler (non-TTY). Level controlled via the
+``GENEVECTOR_LOG_LEVEL`` env var (default ``INFO``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+_configured = False
+_console = None
+
+
+def _is_tty() -> bool:
+    try:
+        return sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+def _configure_root() -> None:
+    global _configured, _console
+    if _configured:
+        return
+
+    level_name = os.environ.get("GENEVECTOR_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    root = logging.getLogger("genevector")
+    root.setLevel(level)
+    root.propagate = False
+
+    if root.handlers:
+        _configured = True
+        return
+
+    handler: logging.Handler
+    if _is_tty():
+        try:
+            from rich.console import Console
+            from rich.logging import RichHandler
+
+            _console = Console()
+            handler = RichHandler(
+                console=_console,
+                show_time=False,
+                show_path=False,
+                rich_tracebacks=True,
+                markup=False,
+            )
+            handler.setFormatter(logging.Formatter("%(message)s"))
+        except ImportError:
+            handler = logging.StreamHandler(sys.stderr)
+            handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    else:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+
+    root.addHandler(handler)
+    _configured = True
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-level logger configured under the ``genevector`` parent."""
+    _configure_root()
+    return logging.getLogger(name)
+
+
+def get_console():
+    """Return the shared rich Console, or None if running in plain mode.
+
+    For internal use by future tasks (panels, progress bars). Most callers
+    should use ``get_logger()`` instead.
+    """
+    _configure_root()
+    return _console

--- a/genevector/data.py
+++ b/genevector/data.py
@@ -14,16 +14,9 @@ from scipy.stats import entropy
 from sklearn import feature_extraction
 import pandas
 
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+from ._logging import get_logger
+
+logger = get_logger(__name__)
 
 class Context(object):
 
@@ -52,7 +45,7 @@ class Context(object):
                     context.metadata[column] = [x.decode("utf-8") for x in context.metadata[column]]
         except Exception as e:
             pass
-        print("Running...")
+        logger.info("Running...")
         context.cells = context.adata.obs.index
         context.cell_index, context.index_cell = Context.index_cells(context.cells)
         if load_expression:
@@ -60,7 +53,7 @@ class Context(object):
                                             context.genes, \
                                             context.cells)
         else:
-            print("Skipping expression load.")
+            logger.info("Skipping expression load.")
         context.gene_index, context.index_gene = Context.index_geneset(adata.var.index.tolist())
         context.gene2id = context.gene_index
         context.id2gene = context.index_gene
@@ -92,18 +85,18 @@ class Context(object):
         index_gene = numpy.array(genes)
         data = collections.defaultdict(list)
         self.expression = collections.defaultdict(dict)
-        print(bcolors.OKGREEN + "Loading Expression." + bcolors.ENDC)
+        logger.info("Loading Expression.")
         normalized_matrix.eliminate_zeros()
         row_indices, column_indices = normalized_matrix.nonzero()
         nonzero_values = normalized_matrix.data
-        print(bcolors.BOLD+"Indexing expression."+bcolors.ENDC)
+        logger.info("Indexing expression.")
         entries = list(zip(nonzero_values, row_indices, column_indices))
         for value, i, j in tqdm.tqdm(entries):
             barcode = cells[i]
             symbol = index_gene[j]
             self.expression[barcode][symbol] = value
             data[symbol].append(barcode)
-        print(bcolors.OKGREEN+"Finished."+bcolors.ENDC)
+        logger.info("Finished.")
         return data
 
     def serialize(self):
@@ -216,11 +209,11 @@ class GeneVectorDataset(Dataset):
         :rtype: anndata.AnnData
         """
         adata.var_names_make_unique()
-        print(bcolors.BOLD + "Removing Genes..."+ bcolors.ENDC)
+        logger.info("Removing Genes...")
         gene_entropy = GeneVectorDataset.get_gene_entropy(adata)
         vgenes = [x for x,y in gene_entropy.items() if y > entropy_threshold]
         adata = adata[:,vgenes]
-        print(bcolors.OKGREEN + "Selecting {} Genes with greater than {} nats entropy.".format(len(vgenes), entropy_threshold)+ bcolors.ENDC)
+        logger.info(f"Selecting {len(vgenes)} Genes with greater than {entropy_threshold} nats entropy.")
         return adata.copy()
 
     def load_targets(self, targets):
@@ -252,7 +245,7 @@ class GeneVectorDataset(Dataset):
 
     def _generate_mi_scores_legacy(self):
         """Legacy MI computation (kept for reference/testing)."""
-        print(bcolors.OKGREEN + "Getting gene pairs combinations." + bcolors.ENDC)
+        logger.info("Getting gene pairs combinations.")
         mi_scores = collections.defaultdict(lambda : collections.defaultdict(float))
         bcs = dict()
         vgenes = []
@@ -266,7 +259,7 @@ class GeneVectorDataset(Dataset):
         for c, p in self.data.expression.items():
             for g,v in p.items():
                 counts[g][c] += int(v)
-        print(bcolors.OKGREEN + "Computing MI for each pair." + bcolors.ENDC)
+        logger.info("Computing MI for each pair.")
         for p1,p2 in tqdm.tqdm(pairs):
             common = bcs[p1].intersection(bcs[p2])
             if len(common) ==0: continue
@@ -312,10 +305,10 @@ class GeneVectorDataset(Dataset):
 
         # --- Compute ---
         if callable(self.target):
-            print(bcolors.OKGREEN + "Computing custom target scores." + bcolors.ENDC)
+            logger.info("Computing custom target scores.")
             self.mi_scores = self.target(X, gene_names, **self.target_kwargs)
         elif isinstance(self.target, str):
-            print(bcolors.OKGREEN + f"Computing '{self.target}' target scores." + bcolors.ENDC)
+            logger.info(f"Computing '{self.target}' target scores.")
             fn = get_target_function(self.target)
             kwargs = {
                 "signed": self.signed_mi,
@@ -341,9 +334,7 @@ class GeneVectorDataset(Dataset):
         c : float
             Scaling factor applied to target scores (score * c^2).
         """
-        print(bcolors.WARNING + "*****************" + bcolors.ENDC)
-        print(bcolors.HEADER + "Loading Dataset." + bcolors.ENDC)
-        print(bcolors.WARNING + "*****************\n" + bcolors.ENDC)
+        logger.info("Loading Dataset.")
 
         # --- Entropy ---
         entropy = self.get_gene_entropy(self.adata)
@@ -353,9 +344,9 @@ class GeneVectorDataset(Dataset):
         if self.mi_scores is None:
             self._compute_target_scores()
         else:
-            print(bcolors.OKCYAN + "Using preloaded target scores." + bcolors.ENDC)
+            logger.info("Using preloaded target scores.")
 
-        print(bcolors.FAIL + "Scores Loaded." + bcolors.ENDC)
+        logger.info("Scores Loaded.")
 
         # --- Rebuild gene index ---
         gene_index = {w: idx for (idx, w) in enumerate(self.data.genes)}
@@ -372,7 +363,7 @@ class GeneVectorDataset(Dataset):
         else:
             self._ent = torch.FloatTensor(ent).to(self.device)
 
-        print(bcolors.OKCYAN + "Ready to train." + bcolors.ENDC)
+        logger.info("Ready to train.")
 
     def _build_training_tensors(self, c=100.):
         """Build i_idx, j_idx, xij tensors using vectorized numpy ops."""

--- a/genevector/embedding.py
+++ b/genevector/embedding.py
@@ -27,16 +27,9 @@ import pandas as pd
 import seaborn as sns
 from sklearn import preprocessing
 
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+from ._logging import get_logger
+
+logger = get_logger(__name__)
 
 class GeneEmbedding(object):
 
@@ -57,16 +50,16 @@ class GeneEmbedding(object):
         if vector not in ("1","2","average"):
             raise ValueError("Select the weight vector from: ('1','2','average')")
         if vector == "average":
-            print("Loading average of 1st and 2nd weights.")
+            logger.info("Loading average of 1st and 2nd weights.")
             avg_embedding = embedding_file.replace(".vec","_avg.vec")
             secondary_weights = embedding_file.replace(".vec","2.vec")
             GeneEmbedding.average_vector_results(embedding_file,secondary_weights,avg_embedding)
             self.embeddings = self.read_embedding(avg_embedding)
         elif vector == "1":
-            print("Loading first weights.")
+            logger.info("Loading first weights.")
             self.embeddings = self.read_embedding(embedding_file)
         elif vector == "2":
-            print("Loading second weights.")
+            logger.info("Loading second weights.")
             secondary_weights = embedding_file.replace(".vec","2.vec")
             self.embeddings = self.read_embedding(secondary_weights)
         self.vector = []
@@ -467,7 +460,7 @@ class CellEmbedding(object):
         self.normalized_vectors = collections.defaultdict(list)
         self._initialize_normalized_vectors(adata_copy.X, genes, barcodes)
 
-        print(bcolors.OKGREEN + "Generating Cell Vectors." + bcolors.ENDC)
+        logger.info("Generating Cell Vectors.")
         cells_with_no_counts = 0
         # Ensure self.data keys are consistent with barcodes for which vectors are made
         temp_cell_vectors = {} # Store vectors before converting to self.matrix to ensure order
@@ -519,13 +512,13 @@ class CellEmbedding(object):
 
 
         if not self.matrix:
-             print(bcolors.WARNING + "No cell vectors were generated. self.matrix is empty." + bcolors.ENDC)
+             logger.warning("No cell vectors were generated. self.matrix is empty.")
              self.dataset_vector = numpy.zeros(self.embed.vector_size if hasattr(self.embed, "vector_size") else 100) # Default size
         else:
              self.dataset_vector = numpy.zeros(numpy.array(self.matrix).shape[1])
-        
-        print(f"Found {cells_with_no_counts} Cells with No Counts / No scorable gene expression.")
-        print(bcolors.BOLD + "Finished CellEmbedding Initialization." + bcolors.ENDC)
+
+        logger.info(f"Found {cells_with_no_counts} Cells with No Counts / No scorable gene expression.")
+        logger.info("Finished CellEmbedding Initialization.")
 
 
     def batch_correct(self, column, reference):
@@ -551,17 +544,17 @@ class CellEmbedding(object):
             batches[batch].append(vec)
         assert reference in batches, "Reference label not found."
         reference_vector = numpy.average(batches.pop(reference),axis=0)
-        print("Generating batch vectors.")
+        logger.info("Generating batch vectors.")
         for batch, vbatches in batches.items():
             if batch != reference:
                 batch_vec = numpy.average(vbatches, axis=0)
                 offset = numpy.subtract(reference_vector,batch_vec)
                 correction_vectors[batch] = offset
-                print("Computing correction vector for {}.".format(batch))
+                logger.info(f"Computing correction vector for {batch}.")
         corrected_matrix = []
         gc.collect()
         self.cell_order = []
-        print("Applying correction vectors.")
+        logger.info("Applying correction vectors.")
         for batch, xvec in zip(labels, self.matrix):
             if  batch != reference:
                 offset = correction_vectors[batch]
@@ -909,7 +902,7 @@ class CellEmbedding(object):
         The 'norm' parameter controls if both target_vec and cell vectors are L2 normalized before similarity calculation.
         """
         if not hasattr(self, 'adata') or self.adata is None:
-            print(bcolors.WARNING + "self.adata is not set. Call get_adata() first. Returning empty distances." + bcolors.ENDC)
+            logger.warning("self.adata is not set. Call get_adata() first. Returning empty distances.")
             return []
         
         # This map uses self.data.keys() and self.matrix from __init__
@@ -932,7 +925,7 @@ class CellEmbedding(object):
             cell_matrix_avg_vector = cell_id_to_matrix_vector_map.get(cell_id)
             
             if cell_matrix_avg_vector is None:
-                print(bcolors.WARNING + f"Cell ID {cell_id} from self.adata.obs.index not found in internal matrix map. Skipping." + bcolors.ENDC)
+                logger.warning(f"Cell ID {cell_id} from self.adata.obs.index not found in internal matrix map. Skipping.")
                 similarities.append(np.nan) # Or some other placeholder like 0.0
                 continue
 
@@ -976,13 +969,13 @@ class CellEmbedding(object):
         :rtype: anndata.AnnData or tuple
         """
         if method == "softmax":
-            print(bcolors.OKBLUE + "Using **SoftMax**" + bcolors.ENDC)
+            logger.info("Using SoftMax")
             pfunc = softmax
         elif method == "sparsemax": # Assuming self.entmax_15 is defined
-            print(bcolors.OKBLUE + "Using **SparseMax (1.5-entmax)**" + bcolors.ENDC)
+            logger.info("Using SparseMax (1.5-entmax)")
             pfunc = self.entmax_15
         elif method == "normalized_exponential":
-            print(bcolors.OKBLUE + f"Using Normalized Exponential (Temp: {temperature})" + bcolors.ENDC)
+            logger.info(f"Using Normalized Exponential (Temp: {temperature})")
             pfunc = lambda x: self.normalized_exponential_vector(x, temperature)
         else:
             raise ValueError(f"Unknown method: {method}. Choose from 'softmax', 'sparsemax', 'normalized_exponential'.")
@@ -995,9 +988,11 @@ class CellEmbedding(object):
         # This relies on self.cell_distance, which iterates self.adata.obs.index.
         # Ensure the input 'adata' is consistent with 'self.adata'.
         if not hasattr(self, 'adata') or self.adata is None or adata is not self.adata:
-             print(bcolors.WARNING + "Input 'adata' might not be consistent with 'self.adata' used by "
-                                   "internal methods like cell_distance. Ensure get_adata() was called and "
-                                   "the same AnnData object is used." + bcolors.ENDC)
+             logger.warning(
+                 "Input 'adata' might not be consistent with 'self.adata' used by "
+                 "internal methods like cell_distance. Ensure get_adata() was called and "
+                 "the same AnnData object is used."
+             )
 
 
         phenotype_names = list(phenotype_markers.keys())
@@ -1008,12 +1003,12 @@ class CellEmbedding(object):
         for pheno_name in tqdm.tqdm(phenotype_names, desc="Computing similarities per phenotype"):
             markers = phenotype_markers[pheno_name]
             if not markers:
-                print(bcolors.WARNING + f"No markers provided for phenotype {pheno_name}. Skipping." + bcolors.ENDC)
+                logger.warning(f"No markers provided for phenotype {pheno_name}. Skipping.")
                 # Assign a default low similarity or handle as appropriate
                 raw_similarity_scores[pheno_name] = [0.0] * len(self.adata.obs) # Or len(adata.obs) if strictly using input adata
                 continue
             
-            print(bcolors.OKGREEN + f"Markers for {pheno_name}: {', '.join(markers[:5])}{'...' if len(markers) > 5 else ''}" + bcolors.ENDC)
+            logger.info(f"Markers for {pheno_name}: {', '.join(markers[:5])}{'...' if len(markers) > 5 else ''}")
             phenotype_vector = self.embed.generate_vector(markers) # Assumes gene names are uppercase or handled by generate_vector
             
             # self.cell_distance calculates similarities for cells in self.adata.obs.index
@@ -1034,7 +1029,7 @@ class CellEmbedding(object):
                 if len(pheno_sims) == num_cells:
                     similarity_matrix_cells_x_phenos[:, i] = pheno_sims
                 else:
-                    print(bcolors.WARNING + f"Similarity score list length mismatch for {pheno_name}. Expected {num_cells}, got {len(pheno_sims)}. Padding with zeros." + bcolors.ENDC)
+                    logger.warning(f"Similarity score list length mismatch for {pheno_name}. Expected {num_cells}, got {len(pheno_sims)}. Padding with zeros.")
                     similarity_matrix_cells_x_phenos[:len(pheno_sims), i] = pheno_sims # Fill what's available
 
         # Apply probability function per cell (i.e., per row of similarity_matrix_cells_x_phenos)
@@ -1069,7 +1064,7 @@ class CellEmbedding(object):
             else:
                 # Should not happen if adata and self.adata are consistent and num_cells matches
                 assigned_phenotypes_list.append(np.nan) # Or some default
-                print(bcolors.WARNING + f"Mismatch in cell counts when assigning probabilities for cell {cell_id}." + bcolors.ENDC)
+                logger.warning(f"Mismatch in cell counts when assigning probabilities for cell {cell_id}.")
 
 
         adata.obs[target_col] = pd.Categorical(assigned_phenotypes_list, categories=phenotype_names) # Use Categorical for defined order
@@ -1133,7 +1128,7 @@ class CellEmbedding(object):
                 odists.append(dist)
             adata.obs[ph] = odists
         for ph in up_and_down:
-            print(ph)
+            logger.info(ph)
             up_genes = up_markers[ph]
             down_genes = down_markers[ph]
             vec_up = self.embed.generate_vector(up_genes)
@@ -1192,11 +1187,11 @@ class CellEmbedding(object):
         :return: Anndata with cell embedding stored in metadata ("obsm").
         :rtype:  anndata.AnnData
         """
-        print(bcolors.OKGREEN + "Loading embedding in X_genevector." + bcolors.ENDC)
-        
+        logger.info("Loading embedding in X_genevector.")
+
         # Ensure self.data and self.matrix are populated from __init__
         if not self.data or not self.matrix:
-            print(bcolors.FAIL + "CellEmbedding data or matrix not initialized. Run constructor properly." + bcolors.ENDC)
+            logger.error("CellEmbedding data or matrix not initialized. Run constructor properly.")
             # Or, attempt to run parts of __init__ if feasible, though better to ensure constructor worked.
             # For now, assume __init__ was successful.
 
@@ -1206,7 +1201,7 @@ class CellEmbedding(object):
         # This makes current_adata.obs.index consistent with self.data.keys() and self.matrix row order.
         cells_with_embeddings = list(self.data.keys())
         if not cells_with_embeddings:
-            print(bcolors.FAIL + "No cells with embeddings found in self.data. Cannot proceed with get_adata." + bcolors.ENDC)
+            logger.error("No cells with embeddings found in self.data. Cannot proceed with get_adata.")
             return current_adata # Or raise an error
 
         current_adata = current_adata[cells_with_embeddings, :].copy() # Ensure it's a copy after filtering
@@ -1223,7 +1218,7 @@ class CellEmbedding(object):
                  x_genevector_list.append(self.matrix[matrix_row_idx])
             else:
                 # This should not happen if cells_with_embeddings was used correctly
-                print(bcolors.WARNING + f"Could not find vector for cell {cell_id_in_adata} in self.matrix. Using zero vector.")
+                logger.warning(f"Could not find vector for cell {cell_id_in_adata} in self.matrix. Using zero vector.")
                 # Determine vector size from first vector in self.matrix or a default
                 vec_size = self.matrix[0].shape[0] if self.matrix and len(self.matrix[0]) > 0 else 100
                 x_genevector_list.append(np.zeros(vec_size))
@@ -1231,7 +1226,7 @@ class CellEmbedding(object):
 
         current_adata.obsm['X_genevector'] = np.array(x_genevector_list)
         
-        print(bcolors.OKGREEN + "Running Scanpy neighbors and umap." + bcolors.ENDC)
+        logger.info("Running Scanpy neighbors and umap.")
         sc.pp.neighbors(current_adata, use_rep="X_genevector", n_neighbors=n_neighbors)
         sc.tl.umap(current_adata, min_dist=min_dist)
         

--- a/genevector/model.py
+++ b/genevector/model.py
@@ -8,17 +8,9 @@ import numpy as np
 import numpy
 import matplotlib.pyplot as plt
 from .embedding import GeneEmbedding
+from ._logging import get_logger
 
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+logger = get_logger(__name__)
 
 class GeneVectorModel(nn.Module):
     """
@@ -201,19 +193,16 @@ class GeneVector(object):
             self.mean_loss_values.append(numpy.mean(self.loss_values[-10:]))
             curr_loss = numpy.mean(self.loss_values[-10:])
             if self.epoch % int(update_interval) == 0:
-                print(bcolors.OKGREEN + "**** Epoch" + bcolors.ENDC,
-                    self.epoch, 
-                    bcolors.HEADER+"\tLoss:"+bcolors.ENDC,
-                    round(np.mean(self.loss_values[-30:]),5))
+                logger.info(f"Epoch {self.epoch} loss: {round(np.mean(self.loss_values[-30:]), 5)}")
             if type(threshold) == float and abs(curr_loss - last_loss) < threshold:
-                print(bcolors.OKCYAN + "Training complete!" + bcolors.ENDC)
+                logger.info("Training complete!")
                 self.model.save_embedding(self.dataset.data.id2gene, self.output_file_name, 0)
                 self.model.save_embedding(self.dataset.data.id2gene, self.output_file_name.replace(".vec","2.vec"), 1)
 
                 return
             last_loss = curr_loss
             self.epoch += 1
-        print(bcolors.WARNING+"Saving model..."+bcolors.ENDC)
+        logger.info("Saving model...")
         self.model.save_embedding(self.dataset.data.id2gene, self.output_file_name, 0)
         self.model.save_embedding(self.dataset.data.id2gene, self.output_file_name.replace(".vec","2.vec"), 1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "scikit-misc>=0.1",
     "leidenalg>=0.9",
     "anndata>=0.8",
+    "rich>=13.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ torch==2.1.0
 scikit-misc==0.3.0
 leidenalg==0.10.1
 anndata==0.10.3
+rich>=13.0

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,55 @@
+"""Tests for genevector._logging."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+import genevector._logging as _gv_logging
+from genevector._logging import get_logger
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_state():
+    """Reset module-level configured flag and parent logger handlers between tests."""
+    _gv_logging._configured = False
+    _gv_logging._console = None
+    parent = logging.getLogger("genevector")
+    parent.handlers.clear()
+    parent.setLevel(logging.NOTSET)
+    yield
+    _gv_logging._configured = False
+    _gv_logging._console = None
+    parent.handlers.clear()
+    parent.setLevel(logging.NOTSET)
+
+
+def test_get_logger_returns_logger():
+    log = get_logger("genevector.data")
+    assert isinstance(log, logging.Logger)
+    assert log.name == "genevector.data"
+
+
+def test_logger_level_from_env(monkeypatch):
+    monkeypatch.setenv("GENEVECTOR_LOG_LEVEL", "WARNING")
+    get_logger("genevector.data")
+    assert logging.getLogger("genevector").level == logging.WARNING
+
+
+def test_logger_level_default_info(monkeypatch):
+    monkeypatch.delenv("GENEVECTOR_LOG_LEVEL", raising=False)
+    get_logger("genevector.data")
+    assert logging.getLogger("genevector").level == logging.INFO
+
+
+def test_handler_idempotent():
+    for _ in range(5):
+        get_logger("genevector.data")
+    assert len(logging.getLogger("genevector").handlers) == 1
+
+
+def test_no_propagation_to_root():
+    get_logger("genevector.data")
+    assert logging.getLogger("genevector").propagate is False


### PR DESCRIPTION
## Summary

- Adds `genevector/_logging.py` with `get_logger(name)` and a shared rich `Console`.
- Replaces all `bcolors` + `print()` usage in `data.py`, `model.py`, and `embedding.py` with module-level loggers.
- Default level is `INFO`; override via `GENEVECTOR_LOG_LEVEL` env var (e.g. `WARNING`, `ERROR`).
- `RichHandler` on TTY, plain `StreamHandler` otherwise (CI logs, redirects, sandboxes).
- Foundation for TASKs 031-035 (panels, progress bars, verbose API, run summaries, unified progress).

## Mapping

| Old | New |
| --- | --- |
| `bcolors.OK*` / `HEADER` / `BOLD` + `print()` | `logger.info()` |
| `bcolors.WARNING` + `print()` | `logger.warning()` |
| `bcolors.FAIL` + `print()` | `logger.error()` |
| Plain `print()` | `logger.info()` |

Decorative asterisk separators around \"Loading Dataset.\" dropped — TASK 031 will reintroduce structured headers via `rich.panel.Panel`.

## Dependency

Adds `rich>=13.0` to `pyproject.toml` and `requirements.txt`. CI installs the wheel, which pulls runtime deps from pyproject — no workflow change needed.

## Test plan

- [x] `pytest tests/test_logging.py -v` (5 new tests: returns logger, env-var level, default INFO, handler idempotence, no propagation)
- [x] Full local suite: **78 passed, 2 xfailed** (pre-existing)
- [x] Smoke (default INFO): produces `INFO: Loading Expression.` style lines, no ANSI escapes
- [x] Smoke (`GENEVECTOR_LOG_LEVEL=WARNING`): cleanly suppresses INFO output
- [ ] CI green across Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)